### PR TITLE
Favorite to Detail debouncer fix

### DIFF
--- a/app/src/main/java/ru/practicum/android/diploma/ui/favorite/FavoriteFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/ui/favorite/FavoriteFragment.kt
@@ -121,6 +121,6 @@ class FavoriteFragment : Fragment() {
         }
     }
     private companion object {
-        const val CLICK_FAVORITE_DEBOUNCE_DELAY = 2000L
+        const val CLICK_FAVORITE_DEBOUNCE_DELAY = 250L
     }
 }


### PR DESCRIPTION
в общем-то, данный дебонсер не совсем нужен, потому что закгрузка вакансии происходит в Details Activity. Просто значительно сократил время задержки, теперь работает без видимой остановки #109 